### PR TITLE
return exit-status:0 when dokku clone

### DIFF
--- a/plugins/apps/subcommands/clone
+++ b/plugins/apps/subcommands/clone
@@ -39,7 +39,7 @@ apps_clone_cmd() {
 
   apps_create "$NEW_APP"
   pushd "$DOKKU_ROOT/$OLD_APP/." >/dev/null
-  find ./* -not \( -name .cache \) | grep -v "./cache" | cpio -pdmu --quiet "$DOKKU_ROOT/$NEW_APP"
+  find ./* \( -name ".cache" -o -name "cache" \) -prune -o -print | cpio -pdmu --quiet "$DOKKU_ROOT/$NEW_APP"
   popd >/dev/null 2>&1 || pushd "/tmp" >/dev/null
   plugn trigger post-app-clone-setup "$OLD_APP" "$NEW_APP"
 


### PR DESCRIPTION
# Env
- dokku version: 0.14.2
- OS: 18.04.1 LTS (Bionic Beaver)
- Shell: GNU bash, version 4.4.19(1)-release (x86_64-pc-linux-gnu)
- find version: find (GNU findutils) 4.7.0-git

# Background
I am trying deploy automation using CI( I tried https://github.com/dokku/dokku/blob/master/docs/community/tutorials/deploying-with-gitlab-ci.md#review-applications ).

I noticed that exit status of `dokku apps:clone` will be 1. I got `Permission Denied` because `find` walks cache (group id: 32767) directory.

```
$ dokku apps:clone old-app new-app
-----> Creating feature-review-application... done
find: ‘./cache/.heroku/python/lib’: Permission denied
find: ‘./cache/.heroku/python/include’: Permission denied
$ echo $?
1
```
Full log(DOKKU_TRACE=1) is here: https://gist.github.com/tamanobi/851770da3d627e57ec4b6324ae6461cf

# Verification
```
#!/bin/bash

function before () {
	mkdir match cache .cache
	chown 32767 cache .cache
}
function teardown () {
	rmdir match cache .cache
}
function test_permission_denied () {
	find ./* -not \( -name .cache \)
	ACTUAL=$?
	EXPECTED=1
	[ $ACTUAL -eq $EXPECTED ] || echo "${FUNCNAME[0]} passed"
}
function test_success () {
	find ./* -not \( -name cache -o -name .cache \)
	ACTUAL=$?
	EXPECTED=0
	[ $ACTUAL -eq $EXPECTED ] || echo "${FUNCNAME[0]} passed"
}

before
test_permission_denied
teardown

before
test_success
teardown
```